### PR TITLE
Update Isort to Version 5.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.9.3" %}
+{% set version = "5.10.0" %}
 
 package:
   name: isort
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/isort/isort-{{ version }}.tar.gz
-  sha256: 9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899
+  sha256: e52ff6d38012b131628cf0f26c51e7bd3a7c81592eefe3ac71411e692f1b9345
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -17,13 +18,15 @@ build:
 
 requirements:
   host:
-    - python >=3.6.1,<4.0
+    - python
     - pip
     - wheel
     - setuptools
     - poetry-core >=1.0.0
+    - toml
   run:
     - python >=3.6.1,<4.0
+    - toml
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     - poetry-core >=1.0.0
     - toml
   run:
-    - python >=3.6.1,<4.0
+    - python >=3.6.1
+    - setuptools
     - toml
 
 test:
@@ -37,6 +38,7 @@ test:
     - isort --help
   requires:
     - pip
+    - python <3.10
 
 about:
   home: https://github.com/timothycrosley/isort

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
-    - isort = isort.main:main
+    - isort = isort.main:identify_imports_main
 
 requirements:
   host:
@@ -26,8 +26,6 @@ requirements:
     - toml
   run:
     - python >=3.6.1
-    - setuptools
-    - toml
 
 test:
   imports:


### PR DESCRIPTION
1. check the upstream
    https://github.com/PyCQA/isort/tree/5.10.0

2. check the pinnings
    https://github.com/PyCQA/isort/blob/5.10.0/setup.cfg
    https://github.com/PyCQA/isort/blob/5.10.0/pyproject.toml
    https://github.com/PyCQA/isort/blob/5.10.0/poetry.lock
    https://github.com/PyCQA/isort/blob/5.10.0/mkdocs.yml

3. check changelogs
    https://github.com/PyCQA/isort/blob/5.10.0/CHANGELOG.md

4. additional research
    https://github.com/conda-forge/isort-feedstock/issues

    There were no open issues at the moment of the review

5. verify dev_url
    https://github.com/timothycrosley/isort

6. verify doc_url
    http://isort.readthedocs.io/en/latest/

7. verify that pip is in the test section
8. verify the test section
9. additional tests

In order to test the `isort` package version `5.10.0` the following command was used:
`conda build isort-feedstock --test` 
The test result was the following:
`All tests passed`

Based on the research findings and on the test results we can conclude that it is safe to update `isort` to version `5.10.0`
