### PR TITLE
isort 5.13.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
 test:
   imports:
     - isort
-    - isort._future
   commands:
     - pip check
     - isort --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,14 +26,17 @@ requirements:
     - colorama >=0.4.6
 
 # Skipping tests since pylama is unavailable
-{% set tests_to_skip = "--ignore=tests/unit/test_deprecated_finders.py" %}
-{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_pylama_isort.py" %}
-{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_format.py" %}
-{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_hooks.py" %}
-{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_importable.py" %}
-{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_place.py" %}
-{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_ticketed_features.py" %}
-{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/profiles/test_black.py" %}
+{% set test_files_to_skip = " --ignore=tests/unit/test_format.py" %}
+{% set test_files_to_skip = test_files_to_skip + " --ignore=tests/unit/test_pylama_isort.py" %}
+# Skipping due to various errors
+{% set tests_to_skip = "test_requirements_dir" %}
+{% set tests_to_skip = tests_to_skip + " or test_requirements_finder" %}
+{% set tests_to_skip = tests_to_skip + " or test_git_hook" %}
+{% set tests_to_skip = tests_to_skip + " or test_importable" %}
+{% set tests_to_skip = tests_to_skip + " or test_module" %}
+{% set tests_to_skip = tests_to_skip + " or test_isort_supports_shared_profiles_issue_970" %}
+{% set tests_to_skip = tests_to_skip + " or test_sort_configurable_sort_issue_1732" %}
+{% set tests_to_skip = tests_to_skip + " or test_black_pyi_file" %}
 
 test:
   source_files:
@@ -43,7 +46,7 @@ test:
   commands:
     - pip check
     - isort --help
-    - pytest tests/unit/ -v {{ tests_to_skip }}
+    - pytest tests/unit/ -v {{ test_files_to_skip }} -k "not({{ tests_to_skip }})"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,20 +19,42 @@ requirements:
   host:
     - python
     - pip
-    - wheel
-    - setuptools
     - poetry-core >=1.0.0
   run:
     - python
+  run_constrained:
+    - colorama >=0.4.6
+
+# Skipping tests since pylama is unavailable
+{% set tests_to_skip = "--ignore=tests/unit/test_deprecated_finders.py" %}
+{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_pylama_isort.py" %}
+{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_format.py" %}
+{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_hooks.py" %}
+{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_importable.py" %}
+{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_place.py" %}
+{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/test_ticketed_features.py" %}
+{% set tests_to_skip = tests_to_skip + " --ignore=tests/unit/profiles/test_black.py" %}
 
 test:
+  source_files:
+    - tests/unit/
   imports:
     - isort
   commands:
     - pip check
     - isort --help
+    - pytest tests/unit/ -v {{ tests_to_skip }}
   requires:
     - pip
+    - pytest
+    - anyio
+    - coverage
+    - exceptiongroup
+    - hypothesis
+    - psutil
+    - pytest-mock
+    - trustme
+    - uvloop
 
 about:
   home: https://github.com/timothycrosley/isort

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,13 +17,13 @@ build:
 
 requirements:
   host:
-    - python >=3.6.1,<4.0
+    - python
     - pip
     - wheel
     - setuptools
     - poetry-core >=1.0.0
   run:
-    - python >=3.6.1,<4.0
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,7 @@ about:
     Python library and plugins for various editors to quickly sort all your
     imports. It currently cleanly supports Python 2.6 - 3.5 using pies to
     achieve this without ugly hacks and/or py2to3.
-  doc_url: http://isort.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/timothycrosley/isort/blob/develop/README.rst
+  doc_url: https://pycqa.github.io/isort/
   dev_url: https://github.com/timothycrosley/isort
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - isort = isort.main:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.9.3" %}
+{% set version = "5.13.2" %}
 
 package:
   name: isort
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/isort/isort-{{ version }}.tar.gz
-  sha256: 9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899
+  sha256: 48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: True  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - isort = isort.main:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_isort_supports_shared_profiles_issue_970" %}
 {% set tests_to_skip = tests_to_skip + " or test_sort_configurable_sort_issue_1732" %}
 {% set tests_to_skip = tests_to_skip + " or test_black_pyi_file" %}
+{% set tests_to_skip = tests_to_skip + " or test_gitignore" %}  # [not osx]
 
 test:
   source_files:
@@ -57,7 +58,7 @@ test:
     - psutil
     - pytest-mock
     - trustme
-    - uvloop
+    - uvloop  # [unix]
 
 about:
   home: https://github.com/timothycrosley/isort


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4934](https://anaconda.atlassian.net/browse/PKG-4934)
- [Upstream repository](https://github.com/PyCQA/isort/tree/5.13.2)
- [Upstream changelog/diff](https://github.com/PyCQA/isort/blob/5.13.2/CHANGELOG.md)

### Explanation of changes:

- Set version and sha256
- Remove noarch
- Small test cleanup
- Linter fixes
- Added upstream tests


[PKG-4934]: https://anaconda.atlassian.net/browse/PKG-4934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ