### PR TITLE
v6.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.13.2" %}
+{% set version = "6.0.1" %}
 
 package:
   name: isort
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/isort/isort-{{ version }}.tar.gz
-  sha256: 48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109
+  sha256: 1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450
 
 build:
-  number: 1
-  skip: True  # [py<38]
+  number: 0
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - isort = isort.main:main
@@ -19,7 +19,7 @@ requirements:
   host:
     - python
     - pip
-    - poetry-core >=1.0.0
+    - hatchling
   run:
     - python
   run_constrained:
@@ -36,7 +36,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_module" %}
 {% set tests_to_skip = tests_to_skip + " or test_isort_supports_shared_profiles_issue_970" %}
 {% set tests_to_skip = tests_to_skip + " or test_sort_configurable_sort_issue_1732" %}
-{% set tests_to_skip = tests_to_skip + " or test_black_pyi_file" %}
+# {% set tests_to_skip = tests_to_skip + " or test_black_pyi_file" %}
 {% set tests_to_skip = tests_to_skip + " or test_gitignore" %}  # [not osx]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_module" %}
 {% set tests_to_skip = tests_to_skip + " or test_isort_supports_shared_profiles_issue_970" %}
 {% set tests_to_skip = tests_to_skip + " or test_sort_configurable_sort_issue_1732" %}
-# {% set tests_to_skip = tests_to_skip + " or test_black_pyi_file" %}
 {% set tests_to_skip = tests_to_skip + " or test_gitignore" %}  # [not osx]
 
 test:


### PR DESCRIPTION
isort  v6.0.1

**Destination channel:** defaults

### Links

- [PKG-6943](https://anaconda.atlassian.net/browse/PKG-6943) 
- [Upstream repository](https://github.com/PyCQA/isort/tree/6.0.1)
- [Upstream changelog/diff](https://github.com/PyCQA/isort/releases)

### Explanation of changes:

- Bump version and SHA
- Remove 3.8 support
- Build system switched to hatchling
- Verified the disabled tests are still failing. 


[PKG-6943]: https://anaconda.atlassian.net/browse/PKG-6943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ